### PR TITLE
Updated page title

### DIFF
--- a/app/views/privacy.html
+++ b/app/views/privacy.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Apply to become an Academy
+  Privacy statement - TRAMS
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Hopefully the tab should now read 'Privacy statement - TRAMS' instead of 'Apply to become an academy'