### PR TITLE
Removing the privacy statement link

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -78,10 +78,6 @@
             text: "Cookie policy"
           },
           {
-            href: "/privacy.html",
-            text: "Privacy statement"
-          },
-          {
             href: "https://webapp-t1pp-sip-a2c.azurewebsites.net/Pages/Terms",
             text: "Terms and Conditions"
           }


### PR DESCRIPTION
The privacy statement is for TRAMS - not Apply to become. 