### PR TITLE
Moved 'start button' to bottom of landing page

### DIFF
--- a/app/views/beforeyoustart.html
+++ b/app/views/beforeyoustart.html
@@ -95,7 +95,12 @@
       <li>information about the consultation the school has carried out, or its plans to consult if it has not happened yet</li>
     </ul>
 
-   <p><a class="govuk-link" href="/start">Apply to become an academy</a></p> 
+    <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+      </svg>
+    </a>
 </div>
   </div>
 {% endblock %}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -44,14 +44,6 @@
       <p>You'll be able to invite other people to help, 
         but the declaration section must be completed by the chair of governors 
         or the school's headteacher acting on their behalf.</p>
-    
-
-      <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-        Start now
-        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
-        </svg>
-      </a>
 
       <h2 class="govuk-heading-m">Before you start</h2>
 
@@ -63,9 +55,15 @@
         <li>have <a class="govuk-link" href="/beforeyoustart">the information and evidence you'll need</a> to hand</li>
       </ul>
 
-
+      <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+        </svg>
+      </a>
+      
     </div>
-
+<!--
     <div class="govuk-grid-column-one-third">
 
       <aside class="app-related-items" role="complementary">
@@ -94,5 +92,7 @@
       </aside>
 
     </div>
+-->
+
   </div>
 {% endblock %}


### PR DESCRIPTION
Also commented out third column and turned the link at the bottom of the 'before you begin' page to a button. 